### PR TITLE
Avoid returning repeated IDs in BDFs

### DIFF
--- a/pyNastran/bdf/bdf_interface/get_card.py
+++ b/pyNastran/bdf/bdf_interface/get_card.py
@@ -317,7 +317,7 @@ class GetCard(GetMethods):
             if isinstance(ids, bool):
                 continue
 
-            for idi in ids:
+            for idi in np.unique(ids):
                 try:
                     card = slot[idi]
                 except KeyError:


### PR DESCRIPTION
Fixes a bug where cards with non-unique IDs are returned multiple times.
