### PR TITLE
Bug fixes when reading and copying BDFs

### DIFF
--- a/pyNastran/bdf/cards/materials.py
+++ b/pyNastran/bdf/cards/materials.py
@@ -934,6 +934,18 @@ class MAT2(AnisotropicMaterial):
         Sc = double_or_blank(card, 15, 'Sc') # or blank?
         Ss = double_or_blank(card, 16, 'Ss') # or blank?
         mcsid = integer_or_blank(card, 17, 'mcsid')
+        # Nastran MAT2 cards can be up to 24 fields long but pyNastran only recognises
+        # the first 18 fields. In the case where fields 18 to 24 are 0 we ignore
+        # them, otherwise we throw an error.
+        if 18 < len(card) <= 24:
+            extra_fields = [np.double(field) for field in card[18:]]
+            if np.isclose(extra_fields, 0).all():
+                card = card[:18]
+            else:
+                raise ValueError('PyNastran cannot handle MAT2 cards with fields 19-24 != 0: ')
+        elif len(card) > 24:
+            raise ValueError('MAT2 cards are expected to a maximum of 24 fields long')
+
         assert len(card) <= 18, 'len(MAT2 card) = %i\ncard=%s' % (len(card), card)
         return MAT2(mid, G11, G12, G13, G22, G23, G33,
                     rho, a1, a2, a3, tref, ge, St, Sc, Ss, mcsid,

--- a/pyNastran/bdf/case_control_deck.py
+++ b/pyNastran/bdf/case_control_deck.py
@@ -52,7 +52,7 @@ class CaseControlDeck:
         # method to avoid modifying the original state.
         state = self.__dict__.copy()
         # Remove the unpicklable entries.
-        del state['log']
+        state.pop('log', None)
         return state
 
     def __init__(self, lines: List[str], log: Optional[Any]=None) -> None:


### PR DESCRIPTION
This PR fixes two bugs we encountered while using pyNastran and are required for Mascots workflow to work.

## Features

* 1e64284 : Fixes a problem when trying to call `copy.deepcopy` on a BDF object, by using `pop` we make sure there is no KeyError.
* d8221bf: Support MAT2 cards up to 24 fields long (see full message for more info)

## Linked to

Development in Mascots work package 3.2
